### PR TITLE
Fix data types too small for larger ellipses

### DIFF
--- a/Adafruit_GFX.cpp
+++ b/Adafruit_GFX.cpp
@@ -169,7 +169,7 @@ void Adafruit_GFX::drawArc(int16_t x, int16_t y, int16_t r, int16_t rs, int16_t 
 
 void Adafruit_GFX::ellipse(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color)
 {
-  int16_t a = abs(x1 - x0), b = abs(y1 - y0), b1 = b & 1; /* values of diameter */
+  long a = abs(x1 - x0), b = abs(y1 - y0), b1 = b & 1; /* values of diameter */
   long dx = 4 * (1 - a) * b * b, dy = 4 * (b1 + 1) * a * a; /* error increment */
   long err = dx + dy + b1 * a * a, e2; /* error of 1.step */
 


### PR DESCRIPTION
Hi @sumotoy - thanks for writing an Adafruit_GFX ellipse function.  I found an issue with it:

Say `x0=0 x1=20 y0=0 y1=25`

Then we have

`a = 20`, `b = 25`

`dx = 4 * (-19) * 25 * 25 = -47500`.  BUT this calculation is done as `int16_t` due to the type of `a` and `b`, and it overflows.

That can be fixed by something like `dx = 4 * (1 - (long)a) * b * b` (and similar for `dy`).  But there are more problems:

`a *= 8 * a` and `b1 = 8 * b * b` overflow when `abs(x1 - x0)` and `abs(y1 - y0)` respectively get up to 64.  Not unreasonable for drawing smooth/subtle curves on larger displays.

So the easiest fix for all of that is to change `a, b, b1` to `long`.
